### PR TITLE
feat: SSH support, remote fallback, pagination, progress,  status bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "webpack-cli": "^5.1.4"
       },
       "engines": {
-        "vscode": "^1.106.0"
+        "vscode": "^1.105.1"
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -367,6 +367,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
       "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^2.4.4",
         "@octokit/graphql": "^4.5.8",
@@ -710,6 +711,7 @@
       "integrity": "sha512-k9fYuQNnypLFcqORNClRykkGOMOj+pV6V91R4GO/l1FDGwpqmSwoOQrOHo3cGaH63e+D3ZiCAOsuS/D2c99j/A==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.15.0",
         "@typescript-eslint/types": "7.15.0",
@@ -1139,6 +1141,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1442,6 +1445,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -1969,6 +1973,7 @@
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4107,6 +4112,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4641,6 +4647,7 @@
       "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4751,6 +4758,7 @@
       "integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -4800,6 +4808,7 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,16 @@
         "icon": "$(git-merge)"
       }
     ],
+    "configuration": {
+      "title": "GitHub Sync Fork",
+      "properties": {
+        "github-sync-fork.debug": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable debug logging to the 'GitHub Sync Fork' output channel."
+        }
+      }
+    },
     "menus": {
       "scm/title": [
         {

--- a/src/cred.ts
+++ b/src/cred.ts
@@ -1,46 +1,43 @@
 import * as vscode from 'vscode';
-import * as Octokit from '@octokit/rest';
+import { Octokit } from '@octokit/rest';
 
 const GITHUB_AUTH_PROVIDER_ID = 'github';
 const SCOPES = ['user:email', 'repo', 'workflow'];
 
 export class Credentials {
-	private octokit: Octokit.Octokit | undefined;
+	private octokit: Octokit | undefined;
 
 	constructor(context: vscode.ExtensionContext) {
-		this.registerListeners(context);
+		context.subscriptions.push(
+			vscode.authentication.onDidChangeSessions(async (e) => {
+				if (e.provider.id === GITHUB_AUTH_PROVIDER_ID) {
+					await this.refresh();
+				}
+			})
+		);
 	}
 
-	private async setOctokit() {
+	private async refresh(): Promise<void> {
 		const session = await vscode.authentication.getSession(GITHUB_AUTH_PROVIDER_ID, SCOPES, { createIfNone: false });
-
-		if (session) {
-			this.octokit = new Octokit.Octokit({
-				auth: session.accessToken
-			});
-
-			return;
-		}
-
-		this.octokit = undefined;
+		this.octokit = session ? new Octokit({ auth: session.accessToken }) : undefined;
 	}
 
-	registerListeners(context: vscode.ExtensionContext): void {
-		context.subscriptions.push(vscode.authentication.onDidChangeSessions(async e => {
-			if (e.provider.id === GITHUB_AUTH_PROVIDER_ID) {
-				await this.setOctokit();
-			}
-		}));
-	}
-	async getOctokit(): Promise<Octokit.Octokit> {
-		if (this.octokit) {
-			return this.octokit;
+	async getOctokit(): Promise<Octokit> {
+		if (!this.octokit) {
+			const session = await vscode.authentication.getSession(GITHUB_AUTH_PROVIDER_ID, SCOPES, { createIfNone: true });
+			this.octokit = new Octokit({ auth: session.accessToken });
 		}
-		const session = await vscode.authentication.getSession(GITHUB_AUTH_PROVIDER_ID, SCOPES, { createIfNone: true });
-		this.octokit = new Octokit.Octokit({
-			auth: session.accessToken
-		});
+		return this.octokit;
+	}
 
+	// Like getOctokit but never prompts — returns undefined if not authenticated.
+	// Used by background operations like the status bar.
+	async tryGetOctokit(): Promise<Octokit | undefined> {
+		if (!this.octokit) {
+			const session = await vscode.authentication.getSession(GITHUB_AUTH_PROVIDER_ID, SCOPES, { createIfNone: false });
+			if (!session) return undefined;
+			this.octokit = new Octokit({ auth: session.accessToken });
+		}
 		return this.octokit;
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,32 +1,74 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 import { Credentials } from "./cred";
 import { Repositories } from "./repo";
 
-// This method is called when your extension is activated
-// Your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
+	const channel = vscode.window.createOutputChannel('GitHub Sync Fork');
+	context.subscriptions.push(channel);
 
-	// This line of code will only be executed once when your extension is activated
-	console.log('Congratulations, your extension "github-sync-fork" is now active!');
-
+	function debugLog(msg: string) {
+		if (vscode.workspace.getConfiguration('github-sync-fork').get<boolean>('debug')) {
+			channel.appendLine(`[${new Date().toISOString()}] ${msg}`);
+			channel.show(true);
+		}
+	}
 
 	const credentials = new Credentials(context);
-	const repositories = new Repositories();
+	const repositories = new Repositories(debugLog);
 
-	const syncBranchDisposable = vscode.commands.registerCommand('github-sync-fork.syncBranch', async (sourceControl?: vscode.SourceControl) => {
-		await repositories.syncBranch(credentials, sourceControl?.rootUri);
-	});
-	context.subscriptions.push(syncBranchDisposable);
+	// Status bar: shows how many commits the fork is behind upstream.
+	// Clicking triggers a sync.
+	const statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
+	statusBar.command = 'github-sync-fork.syncBranch';
+	statusBar.tooltip = 'Commits behind upstream — click to sync';
+	context.subscriptions.push(statusBar);
 
-	// New command: create a GitHub branch in the fork and sync it with upstream
-	const createBranchDisposable = vscode.commands.registerCommand('github-sync-fork.createBranch', async (sourceControl?: vscode.SourceControl) => {
-		await repositories.createBranchAndSync(credentials, sourceControl?.rootUri);
-	});
-	context.subscriptions.push(createBranchDisposable);
+	let updateTimer: NodeJS.Timeout | undefined;
 
+	async function updateStatusBar() {
+		const uri = vscode.workspace.workspaceFolders?.[0]?.uri;
+		if (!uri) { statusBar.hide(); return; }
+
+		statusBar.text = '$(sync~spin) Fork';
+		statusBar.show();
+
+		const behind = await repositories.getForkBehindCount(credentials, uri);
+		debugLog(`updateStatusBar: getForkBehindCount returned ${behind}`);
+		if (behind === undefined) { debugLog('updateStatusBar: hiding status bar (undefined)'); statusBar.hide(); return; }
+
+		statusBar.text = behind === 0 ? '$(check) Fork: up to date' : `$(sync) Fork: ${behind} behind`;
+		debugLog(`updateStatusBar: showing "${statusBar.text}"`);
+		statusBar.show();
+	}
+
+	function scheduleStatusBarUpdate() {
+		if (updateTimer) { clearTimeout(updateTimer); }
+		updateTimer = setTimeout(updateStatusBar, 2000);
+	}
+
+	context.subscriptions.push(
+		{ dispose: () => { if (updateTimer) { clearTimeout(updateTimer); } } },
+		...repositories.subscribeToCurrentBranchChanges(scheduleStatusBarUpdate),
+		// Re-check after auth changes: Credentials.refresh() updates the token
+		// internally but doesn't re-trigger the status bar. This ensures we
+		// re-poll once the user (or another extension like Copilot) signs in.
+		vscode.authentication.onDidChangeSessions((e) => {
+			if (e.provider.id === 'github') { scheduleStatusBarUpdate(); }
+		})
+	);
+
+	scheduleStatusBarUpdate();
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand('github-sync-fork.syncBranch', async (sourceControl?: vscode.SourceControl) => {
+			await repositories.syncBranch(credentials, sourceControl?.rootUri);
+			scheduleStatusBarUpdate();
+		}),
+		vscode.commands.registerCommand('github-sync-fork.createBranch', async (sourceControl?: vscode.SourceControl) => {
+			await repositories.createBranchAndSync(credentials, sourceControl?.rootUri);
+			scheduleStatusBarUpdate();
+		})
+	);
 }
 
-// This method is called when your extension is deactivated
 export function deactivate() {}

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -4,295 +4,348 @@ import * as vscode from 'vscode';
 import * as git from '../git';
 import { Credentials } from './cred';
 
-const octokit = new Octokit();
+type OctokitInstance = InstanceType<typeof Octokit>;
+type GetBranchResponseDataType = GetResponseDataTypeFromEndpointMethod<OctokitInstance['repos']['getBranch']>;
+type GetResponseDataType = GetResponseDataTypeFromEndpointMethod<OctokitInstance['repos']['get']>;
+type ListBranchesResponseDataType = GetResponseDataTypeFromEndpointMethod<OctokitInstance['repos']['listBranches']>;
+type GetAuthenticatedResponseDataType = GetResponseDataTypeFromEndpointMethod<OctokitInstance['users']['getAuthenticated']>;
 
-type GetBranchResponseDataType = GetResponseDataTypeFromEndpointMethod<typeof octokit.repos.getBranch>;
-type GetResponseDataType = GetResponseDataTypeFromEndpointMethod<typeof octokit.repos.get>;
-type ListBranchesResponseDataType = GetResponseDataTypeFromEndpointMethod<typeof octokit.repos.listBranches>;
-type GetAuthenticatedResponseDataType = GetResponseDataTypeFromEndpointMethod<typeof octokit.users.getAuthenticated>;
+interface BranchQuickPickItem extends vscode.QuickPickItem { branchName: string; }
+interface BranchOptionItem extends vscode.QuickPickItem { branchName?: string; }
 
 export class Repositories {
 
     private git: git.API | undefined;
+    private log: (msg: string) => void;
 
-    constructor() {
-        // Make the built-in Git extension's API available
+    constructor(logger: (msg: string) => void = () => {}) {
         this.git = vscode.extensions.getExtension<git.GitExtension>('vscode.git')?.exports?.getAPI(1);
+        this.log = logger;
     }
 
-    private getGitHubRepoName(owner: string, uri: vscode.Uri):string {
-        const repo = this.git?.getRepository(uri);
-        if (!repo) {
-            return "";
-        }
-        const remote = repo.state.remotes.find(remote => remote.name === repo.state.HEAD?.upstream?.remote);
-        if (!remote?.fetchUrl) {
-            return "";
-        }
-        const fetchUri = vscode.Uri.parse(remote.fetchUrl);
-        if (fetchUri.authority !== 'github.com') {
-            return "";
-        }
-        if (fetchUri.path.split('/')[1] !== owner) {
-            return "";
-        }
-        const name = fetchUri.path.split('/').pop();
-        return name?.endsWith('.git') ? name.slice(0, -4) : name ?? "";
+    private resolveUri(uri?: vscode.Uri): vscode.Uri | undefined {
+        return uri ?? vscode.workspace.workspaceFolders?.[0]?.uri;
     }
 
-    private getCurrentBranchName(uri: vscode.Uri):string {
-        const repo = this.git?.getRepository(uri);
-        return repo ? repo.state.HEAD?.name ?? "" : "";
+    // Parses both HTTPS and SSH GitHub remote URLs.
+    private parseGitHubOwnerRepo(fetchUrl: string): { owner: string; repo: string } | undefined {
+        // HTTPS: https://[credentials@]github.com/owner/repo[.git]
+        const httpsMatch = fetchUrl.match(/^https?:\/\/(?:[^@]+@)?github\.com\/([^/]+)\/([^/]+?)(?:\.git)?(?:\/)?$/);
+        if (httpsMatch) { return { owner: httpsMatch[1], repo: httpsMatch[2] }; }
+
+        // SSH: git@github.com:owner/repo[.git]
+        const sshMatch = fetchUrl.match(/^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/);
+        if (sshMatch) { return { owner: sshMatch[1], repo: sshMatch[2] }; }
+
+        return undefined;
     }
-    
-    private async getParentName(userInfo: GetAuthenticatedResponseDataType, octokit: Octokit, repoName: string){
+
+    // Finds the best GitHub remote: tracking remote > 'origin' > any GitHub remote.
+    // Falls back gracefully when the current branch has no upstream tracking set.
+    private resolveGitHubRemote(repo: git.Repository): git.Remote | undefined {
+        const remotes = repo.state.remotes;
+
+        const trackingName = repo.state.HEAD?.upstream?.remote;
+        if (trackingName) {
+            const tracked = remotes.find(r => r.name === trackingName && !!r.fetchUrl && !!this.parseGitHubOwnerRepo(r.fetchUrl!));
+            if (tracked) { return tracked; }
+        }
+
+        const githubRemotes = remotes.filter(r => !!r.fetchUrl && !!this.parseGitHubOwnerRepo(r.fetchUrl!));
+        return githubRemotes.find(r => r.name === 'origin') ?? githubRemotes[0];
+    }
+
+    private getGitHubRepoName(owner: string, uri: vscode.Uri): string {
+        const repo = this.git?.getRepository(uri);
+        if (!repo) { return ""; }
+
+        const remote = this.resolveGitHubRemote(repo);
+        if (!remote?.fetchUrl) { return ""; }
+
+        const parsed = this.parseGitHubOwnerRepo(remote.fetchUrl);
+        if (!parsed || parsed.owner !== owner) { return ""; }
+
+        return parsed.repo;
+    }
+
+    private getCurrentBranchName(uri: vscode.Uri): string {
+        return this.git?.getRepository(uri)?.state.HEAD?.name ?? "";
+    }
+
+    private async getParentInfo(userInfo: GetAuthenticatedResponseDataType, octokit: Octokit, repoName: string): Promise<{ fullName: string; defaultBranch: string } | undefined> {
         try {
             const repo: GetResponseDataType = (await octokit.repos.get({ owner: userInfo.login, repo: repoName })).data;
-            if (repo && repo.parent) {
-                return repo.parent.full_name;
-            }
-        } catch (err) {
-            console.log(err);
+            if (!repo.parent) { return undefined; }
+            return { fullName: repo.parent.full_name, defaultBranch: repo.parent.default_branch };
+        } catch {
+            return undefined;
         }
-        return;
     }
-    
+
     private async getBranchList(userInfo: GetAuthenticatedResponseDataType, octokit: Octokit, uri: vscode.Uri): Promise<ListBranchesResponseDataType> {
-        let branchList: ListBranchesResponseDataType;
         const repoName = this.getGitHubRepoName(userInfo.login, uri);
-        if (repoName === "") {
-            return [];
-        }
+        if (!repoName) { return []; }
+
         const currentBranchName = this.getCurrentBranchName(uri);
         let currentBranch: GetBranchResponseDataType;
         try {
             currentBranch = (await octokit.repos.getBranch({ owner: userInfo.login, repo: repoName, branch: currentBranchName })).data;
-        } catch (err: any) {
+        } catch {
             return [];
         }
-        branchList = (await octokit.repos.listBranches({ owner: userInfo.login, repo: repoName, per_page: 100 })).data ?? [];
 
-        // Put current branch first in the list
-        return [ currentBranch, ...branchList?.filter((branch: any) => branch.name !== currentBranchName) ];
+        const branchList = await octokit.paginate(octokit.repos.listBranches, { owner: userInfo.login, repo: repoName, per_page: 100 });
+        return [currentBranch, ...branchList.filter(b => b.name !== currentBranchName)];
+    }
+
+    private async getRepoContext(credentials: Credentials, uri: vscode.Uri) {
+        const octokit = await credentials.getOctokit();
+        const userInfo: GetAuthenticatedResponseDataType = (await octokit.users.getAuthenticated()).data;
+        const repoName = this.getGitHubRepoName(userInfo.login, uri);
+        return { octokit, userInfo, repoName };
+    }
+
+    private async fetchRemote(uri: vscode.Uri): Promise<void> {
+        const repo = this.git?.getRepository(uri);
+        const remoteName = repo?.state.HEAD?.upstream?.remote;
+        if (remoteName) {
+            try {
+                await repo?.fetch(remoteName);
+            } catch {
+                // local fetch is best-effort
+            }
+        }
+    }
+
+    // Subscribes to branch switches across all open repositories.
+    // Returns disposables that must be pushed to context.subscriptions.
+    subscribeToCurrentBranchChanges(handler: () => void): vscode.Disposable[] {
+        if (!this.git) { return []; }
+        let lastBranch = '';
+        const disposables: vscode.Disposable[] = [];
+
+        const watchRepo = (repo: git.Repository) => {
+            disposables.push(repo.state.onDidChange(() => {
+                const branch = repo.state.HEAD?.name ?? '';
+                if (branch !== lastBranch) {
+                    lastBranch = branch;
+                    handler();
+                }
+            }));
+        };
+
+        this.git.repositories.forEach(watchRepo);
+        disposables.push(this.git.onDidOpenRepository(watchRepo));
+        return disposables;
+    }
+
+    // Returns how many commits the current fork branch is behind the matching upstream branch,
+    // or undefined if not applicable (not a fork, no upstream branch match, not authenticated).
+    async getForkBehindCount(credentials: Credentials, uri: vscode.Uri): Promise<number | undefined> {
+        this.log(`getForkBehindCount: uri=${uri.fsPath}`);
+        try {
+            const octokit = await credentials.tryGetOctokit();
+            this.log(`getForkBehindCount: octokit=${octokit ? 'available' : 'undefined (not authenticated)'}`);
+            if (!octokit) { return undefined; }
+
+            const userInfo: GetAuthenticatedResponseDataType = (await octokit.users.getAuthenticated()).data;
+            this.log(`getForkBehindCount: login=${userInfo.login}`);
+
+            const repoName = this.getGitHubRepoName(userInfo.login, uri);
+            this.log(`getForkBehindCount: repoName=${repoName || '(empty — not a GitHub repo or remote not matched)'}`);
+            if (!repoName) { return undefined; }
+
+            const parentInfo = await this.getParentInfo(userInfo, octokit, repoName);
+            this.log(`getForkBehindCount: parentInfo=${parentInfo ? `${parentInfo.fullName} (default: ${parentInfo.defaultBranch})` : '(undefined — not a fork)'}`);
+            if (!parentInfo) { return undefined; }
+
+            const [parentOwner, parentRepo] = parentInfo.fullName.split('/');
+            const branchName = this.getCurrentBranchName(uri);
+            this.log(`getForkBehindCount: branchName=${branchName || '(empty)'}`);
+            if (!branchName) { return undefined; }
+
+            // Compare fork branch (base) against matching upstream branch (head).
+            // If the upstream doesn't have the same branch name, fall back to the
+            // upstream's default branch (e.g. fork is on 'master', upstream uses 'main').
+            this.log(`getForkBehindCount: compareCommits base=${userInfo.login}:${branchName} head=${parentOwner}:${branchName}`);
+            try {
+                const { data } = await octokit.repos.compareCommits({
+                    owner: parentOwner,
+                    repo: parentRepo,
+                    base: `${userInfo.login}:${branchName}`,
+                    head: `${parentOwner}:${branchName}`
+                });
+                this.log(`getForkBehindCount: ahead_by=${data.ahead_by} status=${data.status}`);
+                return data.ahead_by;
+            } catch (err: any) {
+                this.log(`getForkBehindCount: compareCommits failed — status=${err.status} message=${err.message} — branch not in upstream, hiding`);
+                return undefined;
+            }
+        } catch (err: any) {
+            this.log(`getForkBehindCount: outer catch — ${err.message}`);
+            return undefined;
+        }
     }
 
     async syncBranch(credentials: Credentials, uri?: vscode.Uri) {
-        if (!uri) {
-            const workspaceFolders = vscode.workspace.workspaceFolders;
-            if (!workspaceFolders || workspaceFolders.length === 0) {
-                return;
-            }
-            uri = workspaceFolders[0]?.uri;
-        }
-        if (!uri) {
-            return;
-        }
+        const resolvedUri = this.resolveUri(uri);
+        if (!resolvedUri) { return; }
 
         try {
-            const octokit = await credentials.getOctokit();
-            const userInfo: GetAuthenticatedResponseDataType = (await octokit.users.getAuthenticated()).data;
-            const repoName = this.getGitHubRepoName(userInfo.login, uri);
-            if (!repoName) {
-                vscode.window.showInformationMessage('Current workspace is not associated with a GitHub repository of yours.');
-                return;
-            }
+            await vscode.window.withProgress({
+                location: vscode.ProgressLocation.Notification,
+                title: 'GitHub Sync Fork',
+                cancellable: false
+            }, async (progress) => {
+                progress.report({ message: 'Authenticating...' });
+                const { octokit, userInfo, repoName } = await this.getRepoContext(credentials, resolvedUri);
+                if (!repoName) {
+                    vscode.window.showInformationMessage('Current workspace is not associated with a GitHub repository of yours.');
+                    return;
+                }
 
-            const branchList = await this.getBranchList(userInfo, octokit, uri);
-            if (!branchList || branchList.length === 0) {
-                vscode.window.showInformationMessage('No branches found');
-                return;
-            }
+                progress.report({ message: 'Loading branches...' });
+                const [branchList, parentInfo] = await Promise.all([
+                    this.getBranchList(userInfo, octokit, resolvedUri),
+                    this.getParentInfo(userInfo, octokit, repoName)
+                ]);
 
-            const parentRepo = await this.getParentName(userInfo, octokit, repoName);
-            if (!parentRepo) {
-                vscode.window.showInformationMessage(`Your GitHub repo '${repoName}' doesn't have an upstream.`);
-                return;
-            }
+                if (!branchList.length) {
+                    vscode.window.showInformationMessage('No branches found.');
+                    return;
+                }
+                if (!parentInfo) {
+                    vscode.window.showInformationMessage(`Your GitHub repo '${repoName}' doesn't have an upstream.`);
+                    return;
+                }
 
-            interface BranchQuickPickItem extends vscode.QuickPickItem { branchName: string; }
-            const items: BranchQuickPickItem[] = branchList
-                .map(({ name }) => ({ label: `$(git-branch) ${name}`, branchName: name }));
+                progress.report({ message: '' }); // clear message while user picks
 
-            const selection = await vscode.window.showQuickPick(items, {
-                title: `Sync Fork at GitHub from Upstream`,
-                placeHolder: `Choose branch to sync from '${parentRepo}'`
-            });
-            if (!selection) return;
-
-            const confirm = await vscode.window.showInformationMessage(
-                `Sync the '${selection.branchName}' branch of your GitHub fork with its upstream '${parentRepo}'?`,
-                { modal: true },
-                'Sync'
-            );
-            if (confirm !== 'Sync') return;
-
-            // perform mergeUpstream inline and display concise result
-            try {
-                const res = await octokit.repos.mergeUpstream({
-                    owner: userInfo.login,
-                    repo: repoName,
-                    branch: selection.branchName
+                const items: BranchQuickPickItem[] = branchList.map(({ name }: { name: string }) => ({ label: `$(git-branch) ${name}`, branchName: name }));
+                const selection = await vscode.window.showQuickPick(items, {
+                    title: 'Sync Fork at GitHub from Upstream',
+                    placeHolder: `Choose branch to sync from '${parentInfo.fullName}'`
                 });
-                if (res && res.status === 200) {
-                    vscode.window.showInformationMessage(`The '${selection.branchName}' branch of '${repoName}' has been synced with its upstream.`);
-                } else {
-                    vscode.window.showInformationMessage(`Sync returned status ${res?.status ?? 'unknown'}.`);
-                }
-            } catch (err: any) {
-                vscode.window.showErrorMessage(`Failed to sync branch '${selection.branchName}': ${err.message}`);
-                return;
-            }
+                if (!selection) { return; }
 
-            // fetch remote locally if available
-            const remoteName = this.git?.getRepository(uri)?.state?.HEAD?.upstream?.remote;
-            if (remoteName) {
+                const confirm = await vscode.window.showInformationMessage(
+                    `Sync the '${selection.branchName}' branch of your GitHub fork with its upstream '${parentInfo.fullName}'?`,
+                    { modal: true },
+                    'Sync'
+                );
+                if (confirm !== 'Sync') { return; }
+
+                progress.report({ message: `Syncing '${selection.branchName}'...` });
                 try {
-                    await this.git?.getRepository(uri)?.fetch(remoteName);
-                } catch (err) {
-                    console.log('Local fetch error', err);
+                    const res = await octokit.repos.mergeUpstream({ owner: userInfo.login, repo: repoName, branch: selection.branchName });
+                    if (res.status === 200) {
+                        vscode.window.showInformationMessage(`The '${selection.branchName}' branch of '${repoName}' has been synced with its upstream.`);
+                    } else {
+                        vscode.window.showInformationMessage(`Sync returned status ${res.status}.`);
+                    }
+                } catch (err: any) {
+                    const msg = err.status === 409
+                        ? `Branch '${selection.branchName}' has diverged from upstream and cannot be synced automatically. Reset or rebase it locally first.`
+                        : `Failed to sync branch '${selection.branchName}': ${err.message}`;
+                    vscode.window.showErrorMessage(msg);
+                    return;
                 }
-            }
 
+                progress.report({ message: 'Updating local repository...' });
+                await this.fetchRemote(resolvedUri);
+            });
         } catch (err: any) {
             vscode.window.showErrorMessage(`Error: ${err.message}`);
         }
     }
 
     async createBranchAndSync(credentials: Credentials, uri?: vscode.Uri) {
-        if (!uri) {
-            const workspaceFolders = vscode.workspace.workspaceFolders;
-            if (!workspaceFolders || workspaceFolders.length === 0) {
-                return;
-            }
-            uri = workspaceFolders[0]?.uri;
-        }
-        if (!uri) {
-            return;
-        }
+        const resolvedUri = this.resolveUri(uri);
+        if (!resolvedUri) { return; }
 
         try {
-            const octo = await credentials.getOctokit();
-            const userInfo: GetAuthenticatedResponseDataType = (await octo.users.getAuthenticated()).data;
-            const repoName = this.getGitHubRepoName(userInfo.login, uri);
-            if (!repoName) {
-                vscode.window.showInformationMessage('Current workspace is not associated with a GitHub repository of yours.');
-                return;
-            }
+            await vscode.window.withProgress({
+                location: vscode.ProgressLocation.Notification,
+                title: 'GitHub Sync Fork',
+                cancellable: false
+            }, async (progress) => {
+                progress.report({ message: 'Authenticating...' });
+                const { octokit, userInfo, repoName } = await this.getRepoContext(credentials, resolvedUri);
+                if (!repoName) {
+                    vscode.window.showInformationMessage('Current workspace is not associated with a GitHub repository of yours.');
+                    return;
+                }
 
-            const parentFull = await this.getParentName(userInfo, octo, repoName);
-            if (!parentFull) {
-                vscode.window.showInformationMessage(`Your GitHub repo '${repoName}' doesn't have an upstream.`);
-                return;
-            }
-            const [parentOwner, parentRepo] = parentFull.split('/');
+                progress.report({ message: 'Loading upstream info...' });
+                const parentInfo = await this.getParentInfo(userInfo, octokit, repoName);
+                if (!parentInfo) {
+                    vscode.window.showInformationMessage(`Your GitHub repo '${repoName}' doesn't have an upstream.`);
+                    return;
+                }
+                const [parentOwner, parentRepo] = parentInfo.fullName.split('/');
 
-            // Ask for new branch name - first try to get existing branch name from upstream
-            let newBranchName: string | undefined;
-            const parentBranches = (await octo.repos.listBranches({ owner: parentOwner, repo: parentRepo, per_page: 100 })).data ?? [];
+                progress.report({ message: 'Loading upstream branches...' });
+                const parentBranches = await octokit.paginate(octokit.repos.listBranches, { owner: parentOwner, repo: parentRepo, per_page: 100 });
+                parentBranches.sort((a, b) => a.name.localeCompare(b.name));
 
-            // Sort upstream branches by name
-            parentBranches.sort((a, b) => a.name.localeCompare(b.name));
+                progress.report({ message: '' }); // clear message while user picks
 
-            // Show quick pick with upstream branches (with git icon) and an option to create a new name
-            interface BranchOptionItem extends vscode.QuickPickItem { branchName?: string | undefined; }
-            const branchItems: BranchOptionItem[] = [
-                ...parentBranches.map(b => ({ label: `$(git-branch) ${b.name}`, branchName: b.name })),
-                { label: 'Create new branch name...', branchName: undefined }
-            ];
+                const branchItems: BranchOptionItem[] = [
+                    ...parentBranches.map(b => ({ label: `$(git-branch) ${b.name}`, branchName: b.name })),
+                    { label: 'Create new branch name...', branchName: undefined }
+                ];
 
-            const selectedBranchItem = await vscode.window.showQuickPick(branchItems, {
-                placeHolder: 'Select an upstream branch or create a new one',
-                title: 'Choose branch source'
-            });
-            if (!selectedBranchItem) return;
+                const selectedBranchItem = await vscode.window.showQuickPick(branchItems, {
+                    placeHolder: 'Select an upstream branch or create a new one',
+                    title: 'Choose branch source'
+                });
+                if (!selectedBranchItem) { return; }
 
-            // If user selected to create new branch name
-            if (!selectedBranchItem.branchName) {
-                newBranchName = await vscode.window.showInputBox({
+                const newBranchName = selectedBranchItem.branchName ?? await vscode.window.showInputBox({
                     prompt: 'Enter the name for the new branch to create in your fork',
                     placeHolder: 'e.g. feature/my-new-thing',
-                    validateInput: (value) => value && value.trim().length > 0 ? null : 'Branch name is required'
+                    validateInput: (value) => value?.trim() ? null : 'Branch name is required'
                 });
-            } else {
-                // User selected an existing upstream branch (branchName provided)
-                newBranchName = selectedBranchItem.branchName;
-            }
-             
-            if (!newBranchName) {
-                return;
-            }
+                if (!newBranchName) { return; }
 
-            // List upstream branches to pick the source
-            let upstreamBranches = parentBranches.map(b => b.name);
+                // Put matching upstream branch first
+                const upstreamItems: BranchQuickPickItem[] = [
+                    ...parentBranches.filter(b => b.name === newBranchName),
+                    ...parentBranches.filter(b => b.name !== newBranchName)
+                ].map(b => ({ label: `$(git-branch) ${b.name}`, branchName: b.name }));
 
-            // If the new branch name matches an upstream branch, put it first
-            if (upstreamBranches.includes(newBranchName)) {
-                upstreamBranches = upstreamBranches.filter(name => name !== newBranchName);
-                upstreamBranches.unshift(newBranchName);
-            }
-
-            // present upstream branches with git-branch icon label
-            interface UpstreamItem extends vscode.QuickPickItem { branchName: string; }
-            const upstreamItems: UpstreamItem[] = upstreamBranches.map(name => ({ label: `$(git-branch) ${name}`, branchName: name }));
-
-            const upstreamSelection = await vscode.window.showQuickPick(upstreamItems, {
-                placeHolder: `Select upstream branch from '${parentFull}' to base ${newBranchName} on`,
-                canPickMany: false
-            });
-            if (!upstreamSelection) return;
-            const upstreamBranchName = upstreamSelection.branchName;
-
-            // Show confirmation message before creating branch
-            const confirmCreate = await vscode.window.showInformationMessage(
-                `Create branch '${newBranchName}' in '${repoName}' based on '${parentFull}:${upstreamBranchName}'?`,
-                { modal: true },
-                'Yes'
-            );
-
-            if (confirmCreate !== 'Yes') {
-                return;
-            }
-
-            // Get SHA of upstream branch
-            const upstreamBranch = (await octo.repos.getBranch({ owner: parentOwner, repo: parentRepo, branch: upstreamBranchName })).data;
-            const upstreamSha = upstreamBranch.commit.sha;
-
-            // Create the new branch ref in the user's fork pointing to upstream SHA
-            try {
-                await octo.git.createRef({
-                    owner: userInfo.login,
-                    repo: repoName,
-                    ref: `refs/heads/${newBranchName}`,
-                    sha: upstreamSha
+                const upstreamSelection = await vscode.window.showQuickPick(upstreamItems, {
+                    placeHolder: `Select upstream branch from '${parentInfo.fullName}' to base ${newBranchName} on`
                 });
-                vscode.window.showInformationMessage(`Branch '${newBranchName}' created in '${repoName}' from '${parentFull}:${upstreamBranchName}'.`);
-            } catch (err: any) {
-                vscode.window.showErrorMessage(`Failed to create branch: ${err.message}`);
-                return;
-            }
+                if (!upstreamSelection) { return; }
 
-            // Optionally call mergeUpstream to ensure any additional upstream metadata is applied
-            try {
-                await octo.repos.mergeUpstream({
-                    owner: userInfo.login,
-                    repo: repoName,
-                    branch: newBranchName
-                });
-            } catch (err) {
-                // ignore mergeUpstream errors, branch already points to upstream
-                console.log('mergeUpstream error', err);
-            }
+                const confirm = await vscode.window.showInformationMessage(
+                    `Create branch '${newBranchName}' in '${repoName}' based on '${parentInfo.fullName}:${upstreamSelection.branchName}'?`,
+                    { modal: true },
+                    'Yes'
+                );
+                if (confirm !== 'Yes') { return; }
 
-            // Fetch the remote locally so local repo can see the new branch
-            const remoteName = this.git?.getRepository(uri)?.state?.HEAD?.upstream?.remote;
-            if (remoteName) {
+                progress.report({ message: `Creating branch '${newBranchName}'...` });
+                const upstreamBranch = (await octokit.repos.getBranch({ owner: parentOwner, repo: parentRepo, branch: upstreamSelection.branchName })).data;
                 try {
-                    await this.git?.getRepository(uri)?.fetch(remoteName);
-                } catch (err) {
-                    console.log('Local fetch error', err);
+                    await octokit.git.createRef({ owner: userInfo.login, repo: repoName, ref: `refs/heads/${newBranchName}`, sha: upstreamBranch.commit.sha });
+                    vscode.window.showInformationMessage(`Branch '${newBranchName}' created in '${repoName}' from '${parentInfo.fullName}:${upstreamSelection.branchName}'.`);
+                } catch (err: any) {
+                    vscode.window.showErrorMessage(`Failed to create branch: ${err.message}`);
+                    return;
                 }
-            }
 
+                try {
+                    progress.report({ message: 'Syncing with upstream...' });
+                    await octokit.repos.mergeUpstream({ owner: userInfo.login, repo: repoName, branch: newBranchName });
+                } catch {
+                    // ignore — branch already points to upstream SHA
+                }
+
+                progress.report({ message: 'Updating local repository...' });
+                await this.fetchRemote(resolvedUri);
+            });
         } catch (err: any) {
             vscode.window.showErrorMessage(`Error creating and syncing branch: ${err.message}`);
         }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ const webpack = require('webpack');
 
 /**@type {import('webpack').Configuration}*/
 const config = {
-  target: 'webworker', // vscode extensions run in webworker context for VS Code web 📖 -> https://webpack.js.org/configuration/target/#target
+  target: 'node', // VS Code desktop extensions run in a Node.js context
 
   entry: './src/extension.ts', // the entry point of this extension, 📖 -> https://webpack.js.org/configuration/entry-context/
   output: {
@@ -23,7 +23,7 @@ const config = {
   },
   resolve: {
     // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
-    mainFields: ['browser', 'module', 'main'], // look for `browser` entry point in imported node modules
+    mainFields: ['main'], // use Node.js CJS entry point (avoids octokit dist-web ESM)
     extensions: ['.ts', '.js'],
     alias: {
       // provides alternate implementation for node module and source files
@@ -34,6 +34,16 @@ const config = {
       // for the list of Node.js core module polyfills.
     }
   },
+  plugins: [
+    // Replace `typeof navigator` with "undefined" at bundle time so webpack's
+    // dead-code elimination removes the navigator branch in universal-user-agent
+    // before it can trigger VS Code's deprecated navigator polyfill warning.
+    new webpack.DefinePlugin({ 'typeof navigator': '"undefined"' }),
+    // Silence the "Can't resolve 'encoding'" warning from node-fetch.
+    // node-fetch uses encoding as an optional dependency (try/catch), so it's
+    // safe to ignore — charset detection simply falls back to utf-8.
+    new webpack.IgnorePlugin({ resourceRegExp: /^encoding$/, contextRegExp: /node-fetch/ })
+  ],
   module: {
     rules: [
       {


### PR DESCRIPTION
- Add SSH remote URL parsing (git@github.com:owner/repo) alongside HTTPS
- Fall back to 'origin' or any GitHub remote when branch has no upstream tracking set
- Replace per_page:100 hard cap with octokit.paginate for full branch listing
- Wrap loading phases in vscode.window.withProgress with stage messages
- Show human-readable error when mergeUpstream fails with 409 (diverged branch)
- Add status bar item showing "Fork: N behind" updated on branch switches
- Add Credentials.tryGetOctokit() for silent auth check (no prompt) used by status bar
- Add Repositories.getForkBehindCount() using compareCommits cross-fork API
- Add Repositories.subscribeToCurrentBranchChanges() for branch switch detection
- Refactor: replace import * as Octokit with named import, remove dummy instance used only for type inference (replaced with InstanceType<typeof Octokit>)

Signed-off-by: aspel <lip@lip.net.ua>